### PR TITLE
External dependencies on aws removed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,23 +2,18 @@ name := """aws-request-signer"""
 
 organization := "io.ticofab"
 
-version := "0.1.0"
+version := "0.2.0"
 
-licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+licenses +=("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.10.6", "2.11.7")
 
 libraryDependencies ++= Seq(
-
-  // test framework
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-
-  "com.amazonaws" % "aws-java-sdk-core" % "1.10.19"
-
+  "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 )
 
 bintrayPackageLabels := Seq("scala", "aws")

--- a/src/main/java/org/apache/commons/codec/binary/Hex.java
+++ b/src/main/java/org/apache/commons/codec/binary/Hex.java
@@ -1,0 +1,50 @@
+package org.apache.commons.codec.binary;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class Hex {
+
+    private static final char[] DIGITS_LOWER =
+            {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+
+    private static final char[] DIGITS_UPPER =
+            {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+    public static char[] encodeHex(final byte[] data) {
+        return encodeHex(data, true);
+    }
+
+    public static String encodeHexString(final byte[] data) {
+        return new String(encodeHex(data));
+    }
+
+    public static char[] encodeHex(final byte[] data, final boolean toLowerCase) {
+        return encodeHex(data, toLowerCase ? DIGITS_LOWER : DIGITS_UPPER);
+    }
+
+    protected static char[] encodeHex(final byte[] data, final char[] toDigits) {
+        final int l = data.length;
+        final char[] out = new char[l << 1];
+        // two characters form the hex value.
+        for (int i = 0, j = 0; i < l; i++) {
+            out[j++] = toDigits[(0xF0 & data[i]) >>> 4];
+            out[j++] = toDigits[0x0F & data[i]];
+        }
+        return out;
+    }
+}

--- a/src/main/scala/io/ticofab/AwsCredentials.scala
+++ b/src/main/scala/io/ticofab/AwsCredentials.scala
@@ -1,0 +1,7 @@
+package io.ticofab
+
+case class AccessKeyID(value: String) extends AnyVal
+
+case class SecretAccessKey(value: String) extends AnyVal
+
+case class AwsCredentials(accessKeyID: AccessKeyID, secretAccessKey: SecretAccessKey)

--- a/src/main/scala/io/ticofab/AwsSigner.scala
+++ b/src/main/scala/io/ticofab/AwsSigner.scala
@@ -1,41 +1,40 @@
 package io.ticofab
 
 /**
-  * Copyright 2015 Fabio Tiriticco, Fabway
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+ * Copyright 2015 Fabio Tiriticco, Fabway
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.security.{InvalidKeyException, MessageDigest, NoSuchAlgorithmException}
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
-import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider}
 import org.apache.commons.codec.binary.Hex
-import org.joda.time.DateTime
-import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 
 import scala.collection.immutable.TreeMap
 
 /**
-  * Inspired By: https://github.com/inreachventures/aws-signing-request-interceptor
-  */
-case class AwsSigner(credentialsProvider: AWSCredentialsProvider,
+ * Inspired By: https://github.com/inreachventures/aws-signing-request-interceptor
+ */
+case class AwsSigner(awsCredentials: AwsCredentials,
                      region: String,
                      service: String,
-                     clock: () => DateTime) {
+                     clock: () => LocalDateTime) {
 
   val BASE16MAP = Array[Char]('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
   val HMAC_SHA256 = "HmacSHA256"
@@ -58,7 +57,8 @@ case class AwsSigner(credentialsProvider: AWSCredentialsProvider,
   val AUTHORIZATION = "Authorization"
   val SESSION_TOKEN = "x-amz-security-token"
   val DATE = "date"
-  val DATE_FORMATTER = DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss'Z'")
+  val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
+  val BASIC_DATE_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE
 
   def getSignedHeaders(uri: String,
                        method: String,
@@ -69,7 +69,7 @@ case class AwsSigner(credentialsProvider: AWSCredentialsProvider,
     def queryParamsString(queryParams: Map[String, String]) =
       queryParams.map(pair => pair._1 + "=" + URLEncoder.encode(pair._2, "UTF-8")).mkString("&")
 
-    def sign(stringToSign: String, now: DateTime, credentials: AWSCredentials): String = {
+    def sign(stringToSign: String, now: LocalDateTime, secretAccessKey: String): String = {
       def hmacSHA256(data: String, key: Array[Byte]): Array[Byte] = {
         try {
           val mac: Mac = Mac.getInstance(HMAC_SHA256)
@@ -81,28 +81,28 @@ case class AwsSigner(credentialsProvider: AWSCredentialsProvider,
         }
       }
 
-      def getSignatureKey(now: DateTime, credentials: AWSCredentials): Array[Byte] = {
-        val kSecret: Array[Byte] = (AWS4 + credentials.getAWSSecretKey).getBytes(StandardCharsets.UTF_8)
-        val kDate: Array[Byte] = hmacSHA256(now.toString(ISODateTimeFormat.basicDate()), kSecret)
+      def getSignatureKey(now: LocalDateTime, secretAccessKey: String): Array[Byte] = {
+        val kSecret: Array[Byte] = (AWS4 + secretAccessKey).getBytes(StandardCharsets.UTF_8)
+        val kDate: Array[Byte] = hmacSHA256(now.format(BASIC_DATE_FORMATTER), kSecret)
         val kRegion: Array[Byte] = hmacSHA256(region, kDate)
         val kService: Array[Byte] = hmacSHA256(service, kRegion)
         hmacSHA256(AWS_4_REQUEST, kService)
       }
 
-      Hex.encodeHexString(hmacSHA256(stringToSign, getSignatureKey(now, credentials)))
+      Hex.encodeHexString(hmacSHA256(stringToSign, getSignatureKey(now, secretAccessKey)))
     }
 
     def headerAsString(header: (String, Object)): String =
       if (header._1.equalsIgnoreCase(CONNECTION)) {
         CONNECTION + CLOSE
       } else if (header._1.equalsIgnoreCase(CONTENT_LENGTH) && header._2.equals(ZERO)) {
-        header._1.toLowerCase() + ':'
+        header._1.toLowerCase + ':'
       } else {
-        header._1.toLowerCase() + ':' + header._2
+        header._1.toLowerCase + ':' + header._2
       }
 
-    def getCredentialScope(now: DateTime): String =
-      now.toString(ISODateTimeFormat.basicDate()) + SLASH + region + SLASH + service + AWS4_REQUEST
+    def getCredentialScope(now: LocalDateTime): String =
+      now.format(BASIC_DATE_FORMATTER) + SLASH + region + SLASH + service + AWS4_REQUEST
 
     def hash(payload: Array[Byte]): Array[Byte] =
       try {
@@ -116,30 +116,21 @@ case class AwsSigner(credentialsProvider: AWSCredentialsProvider,
     def toBase16(data: Array[Byte]): String =
       data.map(byte => (BASE16MAP(byte >> 4 & 0xF), BASE16MAP(byte & 0xF))).toList.flatMap(pair => List(pair._1, pair._2)).mkString
 
-    def createStringToSign(canonicalRequest: String, now: DateTime): String =
+    def createStringToSign(canonicalRequest: String, now: LocalDateTime): String =
       AWS4_HMAC_SHA256 + RETURN +
-        now.toString(DATE_FORMATTER) + RETURN +
+        now.format(DATE_FORMATTER) + RETURN +
         getCredentialScope(now) + RETURN +
         toBase16(hash(canonicalRequest.getBytes(StandardCharsets.UTF_8)))
 
     // evaluate current time from the provided clock
-    val now: DateTime = clock.apply()
-
-    // signing credentials
-    val credentials: AWSCredentials = credentialsProvider.getCredentials
+    val now: LocalDateTime = clock.apply()
 
     var result = TreeMap[String, String]()(Ordering.by(_.toLowerCase))
     for ((key, value) <- headers) result += key -> value
 
     if (!result.contains(DATE)) {
-      result += (X_AMZ_DATE -> now.toString(DATE_FORMATTER))
+      result += (X_AMZ_DATE -> now.format(DATE_FORMATTER))
     }
-
-    // TODO
-    //    if (AWSSessionCredentials.class.isAssignableFrom(credentials.getClass()))
-    //    {
-    //      result.put(SESSION_TOKEN, ((AWSSessionCredentials) credentials).getSessionToken());
-    //    }
 
     val headersString: String = result.toMap.map(pair => headerAsString(pair) + RETURN).mkString
     val signedHeaders: List[String] = result.toMap.map(pair => pair._1.toLowerCase).toList
@@ -147,16 +138,16 @@ case class AwsSigner(credentialsProvider: AWSCredentialsProvider,
     val signedHeaderKeys = signedHeaders.mkString(";")
     val canonicalRequest =
       method + RETURN +
-      uri + RETURN +
-      queryParamsString(queryParams) + RETURN +
-      headersString + RETURN +
-      signedHeaderKeys + RETURN +
-      toBase16(hash(payload.getOrElse(EMPTY.getBytes(StandardCharsets.UTF_8))))
+        uri + RETURN +
+        queryParamsString(queryParams) + RETURN +
+        headersString + RETURN +
+        signedHeaderKeys + RETURN +
+        toBase16(hash(payload.getOrElse(EMPTY.getBytes(StandardCharsets.UTF_8))))
 
     val stringToSign = createStringToSign(canonicalRequest, now)
-    val signature = sign(stringToSign, now, credentials)
+    val signature = sign(stringToSign, now, awsCredentials.secretAccessKey.value)
     val authorizationHeader = AWS4_HMAC_SHA256_CREDENTIAL +
-      credentials.getAWSAccessKeyId + SLASH + getCredentialScope(now) +
+      awsCredentials.accessKeyID.value + SLASH + getCredentialScope(now) +
       SIGNED_HEADERS + signedHeaderKeys +
       SIGNATURE + signature
 

--- a/src/test/scala/io/ticofab/AwsSignerSpec.scala
+++ b/src/test/scala/io/ticofab/AwsSignerSpec.scala
@@ -1,36 +1,33 @@
 package io.ticofab
 
 import java.lang.String._
+import java.time.LocalDateTime
 
-import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, BasicAWSCredentials, BasicSessionCredentials}
-import com.amazonaws.internal.StaticCredentialsProvider
-import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 
 class AwsSignerSpec extends FlatSpec with Matchers {
 
   /**
-    * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
-    * (get-vanilla.*)
-    *
-    * GET / http/1.1
-    * Date:Mon, 09 Sep 2011 23:36:00 GMT
-    * Host:host.foo.com
-    *
-    */
+   * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
+   * (get-vanilla.*)
+   *
+   * GET / http/1.1
+   * Date:Mon, 09 Sep 2011 23:36:00 GMT
+   * Host:host.foo.com
+   *
+   */
   "AwsSigner" should "pass the GET vanilla test" in {
 
     // GIVEN
     // Credentials
     val awsAccessKey = "AKIDEXAMPLE"
     val awsSecretKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
-    val credentials: AWSCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey)
-    val awsCredentialsProvider: AWSCredentialsProvider = new StaticCredentialsProvider(credentials)
+    val credentials = new AwsCredentials(AccessKeyID(awsAccessKey), SecretAccessKey(awsSecretKey))
     val region = "us-east-1"
     val service = "host"
 
     // DATE
-    def clock(): DateTime = new DateTime().withDate(2011, 9, 9).withHourOfDay(23).withMinuteOfHour(36).withSecondOfMinute(0)
+    def clock(): LocalDateTime = LocalDateTime.of(2011, 9, 9, 23, 36, 0)
     // weird date : 09 Sep 2011 is a friday, not a monday
     val date = "Mon, 09 Sep 2011 23:36:00 GMT"
 
@@ -41,7 +38,7 @@ class AwsSignerSpec extends FlatSpec with Matchers {
     val headers: Map[String, String] = Map("Date" -> date, "Host" -> host)
     val payload: Option[Array[Byte]] = None
 
-    val signer: AwsSigner = AwsSigner(awsCredentialsProvider, region, service, clock)
+    val signer: AwsSigner = AwsSigner(credentials, region, service, clock)
     val signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload)
 
     // The signature must match the expected signature
@@ -63,26 +60,25 @@ class AwsSignerSpec extends FlatSpec with Matchers {
   }
 
   /**
-    * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
-    * (post-vanilla-query.*)
-    *
-    * POST /?foo=bar http/1.1
-    * Date:Mon, 09 Sep 2011 23:36:00 GMT
-    * Host:host.foo.com
-    *
-    */
+   * Test case given in AWS Signing Test Suite (http://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html)
+   * (post-vanilla-query.*)
+   *
+   * POST /?foo=bar http/1.1
+   * Date:Mon, 09 Sep 2011 23:36:00 GMT
+   * Host:host.foo.com
+   *
+   */
   it should "pass the POST query vanilla test" in {
     // GIVEN
     // Credentials
     val awsAccessKey: String = "AKIDEXAMPLE"
     val awsSecretKey: String = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
-    val credentials: AWSCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey)
-    val awsCredentialsProvider: AWSCredentialsProvider = new StaticCredentialsProvider(credentials)
+    val credentials = new AwsCredentials(AccessKeyID(awsAccessKey), SecretAccessKey(awsSecretKey))
     val region: String = "us-east-1"
     val service: String = "host"
 
     // Date
-    def clock(): DateTime = new DateTime().withDate(2011, 9, 9).withHourOfDay(23).withMinuteOfHour(36).withSecondOfMinute(0)
+    def clock(): LocalDateTime = LocalDateTime.of(2011, 9, 9, 23, 36, 0)
     // weird date : 09 Sep 2011 is a friday, not a monday
     val date = "Mon, 09 Sep 2011 23:36:00 GMT"
 
@@ -96,7 +92,7 @@ class AwsSignerSpec extends FlatSpec with Matchers {
 
     // WHEN
     // The request is signed
-    val signer: AwsSigner = AwsSigner(awsCredentialsProvider, region, service, clock)
+    val signer: AwsSigner = AwsSigner(credentials, region, service, clock)
     val signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload)
 
     // THEN
@@ -119,13 +115,12 @@ class AwsSignerSpec extends FlatSpec with Matchers {
     // Credentials
     val awsAccessKey: String = "AKIDEXAMPLE"
     val awsSecretKey: String = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
-    val credentials: AWSCredentials = new BasicAWSCredentials(awsAccessKey, awsSecretKey)
-    val awsCredentialsProvider: AWSCredentialsProvider = new StaticCredentialsProvider(credentials)
+    val credentials = new AwsCredentials(AccessKeyID(awsAccessKey), SecretAccessKey(awsSecretKey))
     val region: String = "us-east-1"
     val service: String = "host"
 
     // Date
-    def clock(): DateTime = new DateTime().withDate(2011, 9, 9).withHourOfDay(23).withMinuteOfHour(36).withSecondOfMinute(0)
+    def clock(): LocalDateTime = LocalDateTime.of(2011, 9, 9, 23, 36, 0)
     // weird date : 09 Sep 2011 is a friday, not a monday
     val date: String = "20110909T233600Z"
 
@@ -139,7 +134,7 @@ class AwsSignerSpec extends FlatSpec with Matchers {
 
     // WHEN
     // The request is signed
-    val signer: AwsSigner = AwsSigner(awsCredentialsProvider, region, service, clock)
+    val signer: AwsSigner = AwsSigner(credentials, region, service, clock)
     val signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload)
 
     // THEN
@@ -164,13 +159,12 @@ class AwsSignerSpec extends FlatSpec with Matchers {
     val awsAccessKey: String = "AKIDEXAMPLE"
     val awsSecretKey: String = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
     val sessionToken: String = "AKIDEXAMPLESESSION"
-    val credentials: AWSCredentials = new BasicSessionCredentials(awsAccessKey, awsSecretKey, sessionToken)
-    val awsCredentialsProvider: AWSCredentialsProvider = new StaticCredentialsProvider(credentials)
+    val credentials = new AwsCredentials(AccessKeyID(awsAccessKey), SecretAccessKey(awsSecretKey))
     val region: String = "us-east-1"
     val service: String = "host"
 
     // Date
-    def clock(): DateTime = new DateTime().withDate(2011, 9, 9).withHourOfDay(23).withMinuteOfHour(36).withSecondOfMinute(0)
+    def clock(): LocalDateTime = LocalDateTime.of(2011, 9, 9, 23, 36, 0)
     // weird date : 09 Sep 2011 is a friday, not a monday
     val date = "Mon, 09 Sep 2011 23:36:00 GMT"
 
@@ -184,7 +178,7 @@ class AwsSignerSpec extends FlatSpec with Matchers {
 
     // WHEN
     // The request is signed
-    val signer: AwsSigner = AwsSigner(awsCredentialsProvider, region, service, clock)
+    val signer: AwsSigner = AwsSigner(credentials, region, service, clock)
     val signedHeaders = signer.getSignedHeaders(uri, method, queryParams, headers, payload)
 
     // THEN


### PR DESCRIPTION
Hi Fabio,

This patch remove all external dependencies so we do not rely on a on a specific aws sdk version.
I removed
- AWS SDK for Java, 
- Apache Commons Codec,
- Joda-Time libraries.

Not sure if you need it but I wanted to share with you the update I made.

Thanks!
